### PR TITLE
Refactor java role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,14 @@
----
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ansible docker-py molecule
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@ Java
 
 Install Java JREs and optionally JDKs.
 
+
 Role Variables
 --------------
 
 Optional variables:
+- `java_jre_versions`: A list of JRE versions to install, default `[1.8.0]`
+- `java_jdk_install`: If `True` install JDKs corresponding to the JRE versions, default `False`
 
-- `javajreversions`: A list of JRE versions to install, default `[1.8.0]`
-- `javajdkversions`: A list of JDK versions to install, default None
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 # defaults file for roles/java
 
 # List of JRE versions to install
-javajreversions:
+java_jre_versions:
   - 1.8.0
 
-# List of JDK versions to install
-javajdkversions: []
+# Install JDKs corresponding to JREs?
+java_jdk_install: False

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,37 @@
+---
+dependency: []
+
+# Default driver
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: java-jre
+    - name: java-jdk
+
+docker:
+  containers:
+  - name: java-jre
+    image: centos
+    image_version: 7
+  - name: java-jdk
+    image: centos
+    image_version: 7
+
+ansible:
+  host_vars:
+    java-jdk:
+    - java_jdk_install: True
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-java

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,12 @@
   yum:
     name: "java-{{ item }}-openjdk"
     state: present
-  with_items: "{{ javajreversions | default([]) }}"
+  with_items: "{{ java_jre_versions }}"
 
 - name: system packages | install java jdk
   become: yes
   yum:
     name: "java-{{ item }}-openjdk-devel"
     state: present
-  with_items: "{{ javajdkversions | default([]) }}"
+  when: "{{ java_jdk_install }}"
+  with_items: "{{ java_jre_versions }}"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - ansible-role-java

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,20 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_jre_version(Command):
+    assert Command.exists('java')
+    c = Command('java -version')
+    assert c.stderr.startswith('openjdk version "1.8.0')
+
+
+def test_jdk_version(Command, TestinfraBackend):
+    host = TestinfraBackend.get_hostname()
+    if host == 'java-jdk':
+        assert Command.exists('javac')
+        c = Command('javac -version')
+        assert c.stderr.startswith('javac 1.8.0')
+    else:
+        assert not Command.exists('javac')


### PR DESCRIPTION
Use `_` in variable names
Control JDK installation with a boolean instead of requiring a list of versions, since it probably makes sense for this to be the same as the JRE versions

--rebased-from https://github.com/openmicroscopy/infrastructure/pull/219