### PR TITLE
Update molecule.yml and travis requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 sudo: required
 language: python
 
@@ -5,7 +6,7 @@ services:
   - docker
 
 install:
-  - pip install ansible docker-py molecule
+  - pip install ome-ansible-molecule-dependencies
 
 script:
   - molecule test

--- a/molecule.yml
+++ b/molecule.yml
@@ -31,7 +31,7 @@ docker:
 ansible:
   host_vars:
     java-jdk:
-    - java_jdk_install: True
+      java_jdk_install: True
 
 verifier:
   name: testinfra


### PR DESCRIPTION
As discovered in https://github.com/openmicroscopy/ome-ansible-molecule-dependencies/pull/2 this role broke when molecule 1.23 was released