### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Example Playbook
 
     - hosts: servers
       roles:
-         - { role: java }
+         - { role: openmicroscopy.java }
 
 
 Author Information

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Java
 ====
 
+
+[![Build Status](https://travis-ci.org/openmicroscopy/ansible-role-java.svg)](https://travis-ci.org/openmicroscopy/ansible-role-java)
+[![Ansible Role](https://img.shields.io/ansible/role/14303.svg)](https://galaxy.ansible.com/openmicroscopy/java/)
+
 Install Java JREs and optionally JDKs.
 
 


### PR DESCRIPTION
Straightforward README fixes/additions - no release needed

- adds badges linking to CI and deployment
- fixes the example playbook to use the org prefix