### PR TITLE
Add possibility to install temurin java for redhat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,6 @@ java_versions:
 
 # Install JDKs corresponding to JREs?
 java_jdk_install: false
+
+# Use Temuriun (Adoptium) Java
+java_temurin: false

--- a/files/adoptium.repo
+++ b/files/adoptium.repo
@@ -1,0 +1,6 @@
+[Adoptium]
+name=Adoptium
+baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public

--- a/molecule/rockylinux-9/molecule.yml
+++ b/molecule/rockylinux-9/molecule.yml
@@ -16,6 +16,8 @@ platforms:
     image: rockylinux:9
   - name: java-jdk11
     image: rockylinux:9
+  - name: java-11-temurin
+    image: rockylinux:9
 provisioner:
   name: ansible
   playbooks:
@@ -33,6 +35,10 @@ provisioner:
         java_versions:
           - "11"
         java_jdk_install: true
+      java-11-temurin:
+        java_temurin: true
+        java_versions:
+          - "11"
 
 scenario:
   name: rockylinux-9

--- a/molecule/ubuntu-2204/molecule.yml
+++ b/molecule/ubuntu-2204/molecule.yml
@@ -16,6 +16,8 @@ platforms:
     image: ubuntu:22.04
   - name: java-jdk11
     image: ubuntu:22.04
+  - name: java-11-temurin
+    image: ubuntu:22.04
 provisioner:
   name: ansible
   playbooks:
@@ -33,6 +35,10 @@ provisioner:
         java_versions:
           - "11"
         java_jdk_install: true
+      java-11-temurin:
+        java_temurin: true
+        java_versions:
+          - "11"
 
 scenario:
   name: ubuntu-2204

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -13,6 +13,7 @@
   with_items: "{{ java_versions }}"
 
 - name: system packages | install temurin java (ubuntu)
+  when: java_temurin
   become: true
   block:
     - ansible.builtin.apt:
@@ -37,8 +38,9 @@
     - ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 86400
-        name: temurin-{{ java_backwards_compatibility_version.debian[item] |default(item) }}-jdk
+        name: temurin-{{ java_backwards_compatibility_version.debian[item] | default(item) }}-jdk
         state: present
+      with_items: "{{ java_versions }}"
 
 - name: system packages | install java jdk (ubuntu)
   become: true
@@ -49,5 +51,5 @@
       openjdk-{{ java_backwards_compatibility_version.debian[item] |
       default(item) }}-jdk
     state: present
-  when: java_jdk_install
+  when: java_jdk_install and not java_temurin
   with_items: "{{ java_versions }}"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -12,6 +12,34 @@
     state: present
   with_items: "{{ java_versions }}"
 
+- name: system packages | install temurin java (ubuntu)
+  become: true
+  block:
+    - ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 86400
+        pkg:
+          - wget
+          - apt-transport-https
+          - gpg
+        state: present
+
+    - ansible.builtin.apt_key:
+        url: https://packages.adoptium.net/artifactory/api/gpg/key/public
+        state: present
+
+    - ansible.builtin.apt_repository:
+      repo: "deb https://packages.adoptium.net/artifactory/deb {{ ansible_facts.distribution_release }} main"
+      filename: "adoptium"
+      state: present
+      update_cache: true
+
+    - ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 86400
+        name: temurin-{{ java_backwards_compatibility_version.debian[item] |default(item) }}-jdk
+        state: present
+
 - name: system packages | install java jdk (ubuntu)
   become: true
   ansible.builtin.apt:

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -29,10 +29,10 @@
         state: present
 
     - ansible.builtin.apt_repository:
-      repo: "deb https://packages.adoptium.net/artifactory/deb {{ ansible_facts.distribution_release }} main"
-      filename: "adoptium"
-      state: present
-      update_cache: true
+        repo: "deb https://packages.adoptium.net/artifactory/deb {{ ansible_facts.distribution_release }} main"
+        filename: "adoptium"
+        state: present
+        update_cache: true
 
     - ansible.builtin.apt:
         update_cache: true

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,6 +1,26 @@
 ---
 # tasks file for roles/java
 
+- name: repository | copy adoptium repo file (rockylinux)
+  become: true
+  ansible.builtin.copy:
+    src: adoptium.repo
+    dest: /etc/yum.repos.d/adoptium.repo
+    owner: root
+    group: root
+    mode: "0644"
+  when: java_temurin
+
+- name: system packages | install temurin java jre (rockylinux)
+  become: true
+  ansible.builtin.dnf:
+    name: >-
+      temurin-{{ java_backwards_compatibility_version.redhat[item] |
+      default(item) }}-jdk
+    state: present
+  when: java_temurin
+  with_items: "{{ java_versions }}"
+
 - name: system packages | install java jre (rockylinux)
   become: true
   ansible.builtin.dnf:
@@ -8,6 +28,7 @@
       java-{{ java_backwards_compatibility_version.redhat[item] |
       default(item) }}-openjdk
     state: present
+  when: not java_temurin
   with_items: "{{ java_versions }}"
 
 - name: system packages | install java jdk (rockylinux)
@@ -17,5 +38,5 @@
       java-{{ java_backwards_compatibility_version.redhat[item] |
       default(item) }}-openjdk-devel
     state: present
-  when: java_jdk_install
+  when: java_jdk_install and not java_temurin
   with_items: "{{ java_versions }}"


### PR DESCRIPTION
See title. Reason: Redhat Java 11 is already eol, version 8 will be soon: https://endoflife.date/redhat-build-of-openjdk . Temurin has longer support: https://endoflife.date/eclipse-temurin .
